### PR TITLE
Add support snoop continue Elementid properties or method return

### DIFF
--- a/RevitLookup/Commands/SnoopActiveDocCommand.cs
+++ b/RevitLookup/Commands/SnoopActiveDocCommand.cs
@@ -25,7 +25,7 @@ namespace RevitLookupWpf.Commands
 
             try
             {                
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 lookupWindow.SetRvtInstance(commandData.Application.ActiveUIDocument.Document);
                 lookupWindow.Show();
             }

--- a/RevitLookup/Commands/SnoopActiveViewCommand.cs
+++ b/RevitLookup/Commands/SnoopActiveViewCommand.cs
@@ -19,7 +19,7 @@ namespace RevitLookupWpf.Commands
         {
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 lookupWindow.SetRvtInstance(commandData.Application.ActiveUIDocument.Document.ActiveView);
                 lookupWindow.Show();
             }

--- a/RevitLookup/Commands/SnoopCurrentSelectionCommand.cs
+++ b/RevitLookup/Commands/SnoopCurrentSelectionCommand.cs
@@ -31,7 +31,7 @@ namespace RevitLookupWpf.Commands
 
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 var selections = uiDoc.Selection.GetElementIds().Select(p => uiDoc.Document.GetElement(p)).ToList();
 
                 if (!selections.Any())

--- a/RevitLookup/Commands/SnoopDBCommand.cs
+++ b/RevitLookup/Commands/SnoopDBCommand.cs
@@ -29,7 +29,7 @@ namespace RevitLookupWpf.Commands
 
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 var document = commandData.Application.ActiveUIDocument.Document;
                 var elementTypes = new FilteredElementCollector(document).WhereElementIsElementType();
                 var elementInstances = new FilteredElementCollector(document).WhereElementIsNotElementType();

--- a/RevitLookup/Commands/SnoopEdgesCommand.cs
+++ b/RevitLookup/Commands/SnoopEdgesCommand.cs
@@ -24,7 +24,7 @@ namespace RevitLookupWpf.Commands
                 message = Resource.NoActiveDocument;
                 return Result.Cancelled;
             }
-            var lookupWindow = new LookupWindow();
+            var lookupWindow = new LookupWindow(commandData);
             List<GeometryObject> geos = new List<GeometryObject>();
             TaskDialog.Show(Resource.AppName, "Select Ordered Edges,Press Esc To Finish", TaskDialogCommonButtons.Ok);
             while (true)

--- a/RevitLookup/Commands/SnoopFacesCommand.cs
+++ b/RevitLookup/Commands/SnoopFacesCommand.cs
@@ -25,7 +25,7 @@ namespace RevitLookupWpf.Commands
                 message = Resource.NoActiveDocument;
                 return Result.Cancelled;
             }
-            var lookupWindow = new LookupWindow();
+            var lookupWindow = new LookupWindow(commandData);
             List<GeometryObject> geos = new List<GeometryObject>();
             TaskDialog.Show(Resource.AppName, "Select Ordered Faces,Press Esc To Finish", TaskDialogCommonButtons.Ok);
             while (true)

--- a/RevitLookup/Commands/SnoopGeometryCommand.cs
+++ b/RevitLookup/Commands/SnoopGeometryCommand.cs
@@ -27,7 +27,7 @@ namespace RevitLookupWpf.Commands
 
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 var refElem = commandData.Application.ActiveUIDocument.Selection.PickObject(ObjectType.Element);
                 GeometryElement geometryElement = commandData.Application.ActiveUIDocument.Document.GetElement(refElem)
                     .get_Geometry(new Options());

--- a/RevitLookup/Commands/SnoopLinkedElementCommand.cs
+++ b/RevitLookup/Commands/SnoopLinkedElementCommand.cs
@@ -31,7 +31,7 @@ namespace RevitLookupWpf.Commands
 
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 List<Element> selections = new List<Element>();
                 IList<Reference> references = uiDoc.Selection.PickObjects(ObjectType.LinkedElement,Resource.PickLinkElements);
                 foreach (Reference r in references)

--- a/RevitLookup/Commands/SnoopPointsCommand.cs
+++ b/RevitLookup/Commands/SnoopPointsCommand.cs
@@ -64,7 +64,7 @@ namespace RevitLookupWpf.Commands
                     transaction.RollBack();
                     return Result.Succeeded;
                 }
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 if (xyzs.Count == 1) lookupWindow.SetRvtInstance(xyzs.FirstOrDefault());
                 else if(xyzs.Any())
                 {

--- a/RevitLookup/Commands/SnoopPointsOnEleCommand.cs
+++ b/RevitLookup/Commands/SnoopPointsOnEleCommand.cs
@@ -31,7 +31,7 @@ namespace RevitLookupWpf.Commands
 
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
 
                 var selections = uiDoc.Selection.GetElementIds().Select(p => uiDoc.Document.GetElement(p)).ToList();
 

--- a/RevitLookup/Commands/SnoopUIApplicationCommand.cs
+++ b/RevitLookup/Commands/SnoopUIApplicationCommand.cs
@@ -19,7 +19,7 @@ namespace RevitLookupWpf.Commands
         {
             try
             {
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(commandData);
                 lookupWindow.SetRvtInstance(commandData.Application);
                 lookupWindow.Show();
             }

--- a/RevitLookup/InstanceTree/ElementIdInstanceNode.cs
+++ b/RevitLookup/InstanceTree/ElementIdInstanceNode.cs
@@ -29,7 +29,7 @@ namespace RevitLookupWpf.InstanceTree
             InstanceNode node;
             Document doc = Data.Application.ActiveUIDocument.Document;
             Element e = doc.GetElement(elementId);
-            if (e != null) node = new ElementInstanceNode(e);
+            if (e != null) node = new ElementInstanceNode(e,true);
             else node = new ElementIdInstanceNode(elementId);
             return node;
         }

--- a/RevitLookup/InstanceTree/ElementIdInstanceNode.cs
+++ b/RevitLookup/InstanceTree/ElementIdInstanceNode.cs
@@ -24,12 +24,12 @@ namespace RevitLookupWpf.InstanceTree
                 Name += $"({rvtObjcet.IntegerValue})";
             }
         }
-        public InstanceNode ToElementInstanceNode()
+        public InstanceNode ToElementInstanceNode(bool isRoot)
         {
             InstanceNode node;
             Document doc = Data.Application.ActiveUIDocument.Document;
             Element e = doc.GetElement(elementId);
-            if (e != null) node = new ElementInstanceNode(e,true);
+            if (e != null) node = new ElementInstanceNode(e,isRoot);
             else node = new ElementIdInstanceNode(elementId);
             return node;
         }

--- a/RevitLookup/InstanceTree/ElementIdInstanceNode.cs
+++ b/RevitLookup/InstanceTree/ElementIdInstanceNode.cs
@@ -1,15 +1,37 @@
 ﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
 
 namespace RevitLookupWpf.InstanceTree
 {
     public class ElementIdInstanceNode : InstanceNode<ElementId>
     {
+        private ExternalCommandData Data;
+        private ElementId elementId;
         public ElementIdInstanceNode(ElementId rvtObjcet) : base(rvtObjcet)
         {
+            elementId = rvtObjcet;
             if (rvtObjcet != null)
             {
                 Name += $"({rvtObjcet.IntegerValue})";
             }
+        }
+        public ElementIdInstanceNode(ElementId rvtObjcet,ExternalCommandData data) : base(rvtObjcet)
+        {
+            Data = data;
+            elementId = rvtObjcet;
+            if (rvtObjcet != null)
+            {
+                Name += $"({rvtObjcet.IntegerValue})";
+            }
+        }
+        public InstanceNode ToElementInstanceNode()
+        {
+            InstanceNode node;
+            Document doc = Data.Application.ActiveUIDocument.Document;
+            Element e = doc.GetElement(elementId);
+            if (e != null) node = new ElementInstanceNode(e);
+            else node = new ElementIdInstanceNode(elementId);
+            return node;
         }
     }
 }

--- a/RevitLookup/InstanceTree/ElementInstanceNode.cs
+++ b/RevitLookup/InstanceTree/ElementInstanceNode.cs
@@ -4,11 +4,12 @@ namespace RevitLookupWpf.InstanceTree
 {
     public class ElementInstanceNode : InstanceNode<Element>
     {
-        public ElementInstanceNode(Element rvtObjcet) : base(rvtObjcet)
+        public ElementInstanceNode(Element rvtObjcet,bool isRoot) : base(rvtObjcet)
         {
             if (rvtObjcet != null)
             {
-                Name += $"({rvtObjcet.Name})";
+                if(isRoot) Name += $"({rvtObjcet.Id.IntegerValue})";
+                else Name += $"({rvtObjcet.Name})";
             }
         }
     }

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -59,13 +59,9 @@ namespace RevitLookupWpf.InstanceTree
                         Children.Add(node);
                         break;
                     case ElementId elementId:
-                        Document doc = Data.Application.ActiveUIDocument.Document;
-                        Element e = doc.GetElement(elementId);
-                        if (e != null) node = new ElementInstanceNode(e);
-                        else node = new ElementIdInstanceNode(elementId);
+                        node = new ElementIdInstanceNode(elementId, Data).ToElementInstanceNode();
                         Children.Add(node);
                         break;
-                    
                     case InstanceBinding instanceBinding:
                         node = new InstanceBindingInstanceNode(instanceBinding);
                         Children.Add(node);
@@ -135,6 +131,7 @@ namespace RevitLookupWpf.InstanceTree
             }
             if (Children.Any()) Children = Children.OrderBy(x => x.Name).ToObservableCollection();
         }
+
     }
 
     public abstract class InstanceNode : ObservableObject
@@ -164,10 +161,7 @@ namespace RevitLookupWpf.InstanceTree
                         node = new ElementInstanceNode(element);
                         break;
                     case ElementId elementId:
-                        Document document = data.Application.ActiveUIDocument.Document;
-                        Element e = document.GetElement(elementId);
-                        if (e != null) node = new ElementInstanceNode(e);
-                        else node = new ElementIdInstanceNode(elementId);
+                        node = new ElementIdInstanceNode(elementId, data).ToElementInstanceNode();
                         break;
                     case Document doc:
                         node = new DocumentInstanceNode(doc);

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -141,7 +141,7 @@ namespace RevitLookupWpf.InstanceTree
         #endregion
 
         #region Ctor
-        public static InstanceNode Create<TRvtObjcet>(TRvtObjcet obj)
+        public static InstanceNode Create<TRvtObjcet>(TRvtObjcet obj,ExternalCommandData data)
         {
             if (obj == null)
             {
@@ -160,7 +160,10 @@ namespace RevitLookupWpf.InstanceTree
                         node = new ElementInstanceNode(element);
                         break;
                     case ElementId elementId:
-                        node = new ElementIdInstanceNode(elementId);
+                        Document document = data.Application.ActiveUIDocument.Document;
+                        Element e = document.GetElement(elementId);
+                        if (e != null) node = new ElementInstanceNode(e);
+                        else node = new ElementIdInstanceNode(elementId);
                         break;
                     case Document doc:
                         node = new DocumentInstanceNode(doc);

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -65,7 +65,7 @@ namespace RevitLookupWpf.InstanceTree
                         Children.Add(node);
                         break;
                     case ElementId elementId:
-                        node = new ElementIdInstanceNode(elementId, Data).ToElementInstanceNode();
+                        node = new ElementIdInstanceNode(elementId, Data).ToElementInstanceNode(false);
                         Children.Add(node);
                         break;
                     case InstanceBinding instanceBinding:
@@ -170,7 +170,7 @@ namespace RevitLookupWpf.InstanceTree
                         node = new WorksetIdInstanceNode(worksetId, data).ToWorksetInstanceNode();
                         break;
                     case ElementId elementId:
-                        node = new ElementIdInstanceNode(elementId, data).ToElementInstanceNode();
+                        node = new ElementIdInstanceNode(elementId, data).ToElementInstanceNode(true);
                         break;
                     case Document doc:
                         node = new DocumentInstanceNode(doc);

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -2,11 +2,13 @@
 using System.Collections.ObjectModel;
 using System.Windows;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.Exceptions;
 using Autodesk.Revit.UI;
 using GalaSoft.MvvmLight;
 using RevitLookupWpf.Extension;
 using RevitLookupWpf.Helpers;
 using RevitLookupWpf.PropertySys;
+using ArgumentNullException = System.ArgumentNullException;
 
 namespace RevitLookupWpf.InstanceTree
 {
@@ -56,6 +58,10 @@ namespace RevitLookupWpf.InstanceTree
                 {
                     case Element element:
                         node = new ElementInstanceNode(element);
+                        Children.Add(node);
+                        break;
+                    case WorksetId worksetId:
+                        node = new WorksetIdInstanceNode(worksetId, Data).ToWorksetInstanceNode();
                         Children.Add(node);
                         break;
                     case ElementId elementId:
@@ -160,6 +166,9 @@ namespace RevitLookupWpf.InstanceTree
                     case Element element:
                         node = new ElementInstanceNode(element);
                         break;
+                    case WorksetId worksetId:
+                        node = new WorksetIdInstanceNode(worksetId, data).ToWorksetInstanceNode();
+                        break;
                     case ElementId elementId:
                         node = new ElementIdInstanceNode(elementId, data).ToElementInstanceNode();
                         break;
@@ -171,6 +180,8 @@ namespace RevitLookupWpf.InstanceTree
                         break;
                 }
             }
+
+            if (node == null) throw new ArgumentNullException(nameof(obj));
             return node;
         }
 

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -57,7 +57,7 @@ namespace RevitLookupWpf.InstanceTree
                 switch (item)
                 {
                     case Element element:
-                        node = new ElementInstanceNode(element);
+                        node = new ElementInstanceNode(element,false);
                         Children.Add(node);
                         break;
                     case WorksetId worksetId:
@@ -164,7 +164,7 @@ namespace RevitLookupWpf.InstanceTree
                 switch (obj)
                 {
                     case Element element:
-                        node = new ElementInstanceNode(element);
+                        node = new ElementInstanceNode(element,true);
                         break;
                     case WorksetId worksetId:
                         node = new WorksetIdInstanceNode(worksetId, data).ToWorksetInstanceNode();

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -34,12 +34,12 @@ namespace RevitLookupWpf.InstanceTree
     public class IEnumerableInstanceNode : InstanceNode<IEnumerable>
     {
         private readonly IEnumerable _rvtObjcet;
-
-        public IEnumerableInstanceNode(IEnumerable rvtObjcet) : base(rvtObjcet)
+        private ExternalCommandData Data;
+        public IEnumerableInstanceNode(IEnumerable rvtObjcet,ExternalCommandData data) : base(rvtObjcet)
         {
             _rvtObjcet = rvtObjcet;
-
             Name = rvtObjcet?.GetType().Name;
+            Data = data;
             GetChild();
         }
 
@@ -59,9 +59,13 @@ namespace RevitLookupWpf.InstanceTree
                         Children.Add(node);
                         break;
                     case ElementId elementId:
-                        node = new ElementIdInstanceNode(elementId);
+                        Document doc = Data.Application.ActiveUIDocument.Document;
+                        Element e = doc.GetElement(elementId);
+                        if (e != null) node = new ElementInstanceNode(e);
+                        else node = new ElementIdInstanceNode(elementId);
                         Children.Add(node);
                         break;
+                    
                     case InstanceBinding instanceBinding:
                         node = new InstanceBindingInstanceNode(instanceBinding);
                         Children.Add(node);
@@ -150,7 +154,7 @@ namespace RevitLookupWpf.InstanceTree
             InstanceNode node;
             if (obj is IEnumerable enumble)
             {
-                node = new IEnumerableInstanceNode(enumble);
+                node = new IEnumerableInstanceNode(enumble,data);
             }
             else
             {

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -148,7 +148,7 @@ namespace RevitLookupWpf.InstanceTree
         #endregion
 
         #region Ctor
-        public static InstanceNode Create<TRvtObjcet>(TRvtObjcet obj,ExternalCommandData data)
+        public static InstanceNode Create<TRvtObject>(TRvtObject obj,ExternalCommandData data)
         {
             if (obj == null)
             {

--- a/RevitLookup/InstanceTree/WorksetIdInstanceNode.cs
+++ b/RevitLookup/InstanceTree/WorksetIdInstanceNode.cs
@@ -1,0 +1,37 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace RevitLookupWpf.InstanceTree
+{
+    public class WorksetIdInstanceNode : InstanceNode<WorksetId>
+    {
+        private ExternalCommandData Data;
+        private WorksetId elementId;
+        public WorksetIdInstanceNode(WorksetId rvtObjcet) : base(rvtObjcet)
+        {
+            elementId = rvtObjcet;
+            if (rvtObjcet != null)
+            {
+                Name += $"({rvtObjcet.IntegerValue})";
+            }
+        }
+        public WorksetIdInstanceNode(WorksetId rvtObjcet,ExternalCommandData data) : base(rvtObjcet)
+        {
+            Data = data;
+            elementId = rvtObjcet;
+            if (rvtObjcet != null)
+            {
+                Name += $"({rvtObjcet.IntegerValue})";
+            }
+        }
+        public InstanceNode ToWorksetInstanceNode()
+        {
+            InstanceNode node;
+            Document doc = Data.Application.ActiveUIDocument.Document;
+            WorksetTable worksetTable = doc.GetWorksetTable();
+            Workset workset = worksetTable.GetWorkset(elementId);
+            node = new InstanceNode<object>(workset);
+            return node;
+        }
+    }
+}

--- a/RevitLookup/InstanceTree/WorksetIdInstanceNode.cs
+++ b/RevitLookup/InstanceTree/WorksetIdInstanceNode.cs
@@ -30,7 +30,7 @@ namespace RevitLookupWpf.InstanceTree
             Document doc = Data.Application.ActiveUIDocument.Document;
             WorksetTable worksetTable = doc.GetWorksetTable();
             Workset workset = worksetTable.GetWorkset(elementId);
-            node = new InstanceNode<object>(workset);
+            node = new WorksetInstanceNode(workset);
             return node;
         }
     }

--- a/RevitLookup/InstanceTree/WorksetInstanceNode.cs
+++ b/RevitLookup/InstanceTree/WorksetInstanceNode.cs
@@ -1,0 +1,16 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace RevitLookupWpf.InstanceTree
+{
+    public class WorksetInstanceNode : InstanceNode<Workset>
+    {
+        public WorksetInstanceNode(Workset workset) : base(workset)
+        {
+            if (workset != null)
+            {
+                Name += $"({workset.Id})";
+            }
+        }
+    }
+}

--- a/RevitLookup/View/LookupWindow.xaml.cs
+++ b/RevitLookup/View/LookupWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Interop;
+using Autodesk.Revit.UI;
 using GalaSoft.MvvmLight.Messaging;
 using RevitLookupWpf.Helpers;
 using RevitLookupWpf.ViewModel;
@@ -17,18 +18,20 @@ namespace RevitLookupWpf.View
         public LookupWindow()
         {
             InitializeComponent();
-            _viewModel = new LookupWindowViewModel(this);
-            _viewModel.CloseAction = Close;
-            this.Closed += LookupWindow_Closed;
-            DataContext = _viewModel;
             this.SetOwnerWindow();
+            this.Closed += LookupWindow_Closed;
+        }
+        public LookupWindow(ExternalCommandData data) : this()
+        {
+            _viewModel = new LookupWindowViewModel(this,data);
+            _viewModel.CloseAction = Close;
+            DataContext = _viewModel;
         }
 
         public bool SetRvtInstance<TRvtObject>(TRvtObject rvtObject)
         {
             return _viewModel.SetRvtInstance(rvtObject);
         }
-
         private void LookupWindow_Closed(object sender, EventArgs e)
         {
             this.Closed -= LookupWindow_Closed;

--- a/RevitLookup/ViewModel/LookupViewModel.cs
+++ b/RevitLookup/ViewModel/LookupViewModel.cs
@@ -5,16 +5,18 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
+using GalaSoft.MvvmLight.Messaging;
 using RevitLookupWpf.Helpers;
-using RevitLookupWpf.InstanceTree;
 using RevitLookupWpf.PropertySys;
 using RevitLookupWpf.PropertySys.BaseProperty;
 using RevitLookupWpf.PropertySys.BaseProperty.MethodType;
 using RevitLookupWpf.PropertySys.BaseProperty.ReferenceType;
 using RevitLookupWpf.View;
+using InstanceNode = RevitLookupWpf.InstanceTree.InstanceNode;
 
 namespace RevitLookupWpf.ViewModel
 {
@@ -28,12 +30,13 @@ namespace RevitLookupWpf.ViewModel
         private RelayCommand _openInNewWindowCommand;
         private RelayCommand _helpCommand;
         public LookupWindow _lookupWindow;
+        public ExternalCommandData _data;
 
-        public LookupViewModel(LookupWindow lookupWindow)
+        public LookupViewModel(LookupWindow lookupWindow,ExternalCommandData data)
         {
             _lookupWindow = lookupWindow;
+            _data = data;
         }
-
         public ObservableCollection<InstanceNode> Roots
         {
             get => _roots; set
@@ -123,7 +126,6 @@ namespace RevitLookupWpf.ViewModel
                 OpenInNewWindowCommand.RaiseCanExecuteChanged();
             }
         }
-
         public RelayCommand OpenInNewWindowCommand => _openInNewWindowCommand ??= new RelayCommand(OpenInNewWindow, CanOpenInNewWindow);
         public RelayCommand HelpCommand => _helpCommand ?? new RelayCommand(HelpClick);
 
@@ -158,7 +160,7 @@ namespace RevitLookupWpf.ViewModel
 
         private void OpenInNewWindow()
         {
-            var lookupWindow = new LookupWindow();
+            var lookupWindow = new LookupWindow(_data);
             if (SelectedProperty is DefaultObjectProperty objectProperty)
             {
                 lookupWindow.SetRvtInstance(objectProperty.Value);
@@ -166,7 +168,8 @@ namespace RevitLookupWpf.ViewModel
             else if (SelectedProperty is MethodProperty methodProperty)
             {
                 lookupWindow.SetRvtInstance(methodProperty.MethodValue);
-            }else if(SelectedProperty is ParametersProperty parametersProperty)
+            }
+            else if(SelectedProperty is ParametersProperty parametersProperty)
             {
                 lookupWindow.SetRvtInstance(parametersProperty.Value);
             }    

--- a/RevitLookup/ViewModel/LookupWindowViewModel.cs
+++ b/RevitLookup/ViewModel/LookupWindowViewModel.cs
@@ -2,10 +2,12 @@
 using System.Windows.Input;
 using GalaSoft.MvvmLight.CommandWpf;
 using GalaSoft.MvvmLight.Messaging;
-using RevitLookupWpf.InstanceTree;
 using RevitLookupWpf.PropertySys;
 using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
 using RevitLookupWpf.View;
+using InstanceNode = RevitLookupWpf.InstanceTree.InstanceNode;
 
 namespace RevitLookupWpf.ViewModel
 {
@@ -22,7 +24,7 @@ namespace RevitLookupWpf.ViewModel
 
         #region Ctor
 
-        public LookupWindowViewModel(LookupWindow lookupWindow):base(lookupWindow)
+        public LookupWindowViewModel(LookupWindow lookupWindow,ExternalCommandData data):base(lookupWindow,data)
         {
             LookupData = this;
             Items = new ObservableCollection<LookupViewModel>(GetAllSnoopItems());
@@ -44,7 +46,7 @@ namespace RevitLookupWpf.ViewModel
         #region Public Methods
         public bool SetRvtInstance<TRvtObject>(TRvtObject rvtObject)
         {
-            var root = InstanceNode.Create<TRvtObject>(rvtObject);
+            var root = InstanceNode.Create(rvtObject,_data);
             root.IsSelected = true;
             root.IsExpanded = true;
             LookupData.Roots = new ObservableCollection<InstanceNode>() { root };
@@ -53,7 +55,6 @@ namespace RevitLookupWpf.ViewModel
 
             return LookupData.Roots.Any();
         }
-
         public ICommand SelectedItemChangedCommand
         {
             get
@@ -101,9 +102,9 @@ namespace RevitLookupWpf.ViewModel
                 return;
             }
 
-            var vm = new LookupViewModel(_lookupWindow);
+            var vm = new LookupViewModel(_lookupWindow,_data);
 
-            var root = InstanceNode.Create(objectMessage.RvtObject);
+            var root = InstanceNode.Create(objectMessage.RvtObject,_data);
 
             vm.Roots = new ObservableCollection<InstanceNode>() { root };
 

--- a/RevitLookup/ViewModel/SnoopSearchViewModel.cs
+++ b/RevitLookup/ViewModel/SnoopSearchViewModel.cs
@@ -57,7 +57,7 @@ namespace RevitLookupWpf.ViewModel
                     }
                 }
                 SearchWindow.Close();
-                var lookupWindow = new LookupWindow();
+                var lookupWindow = new LookupWindow(Data);
                 lookupWindow.SetRvtInstance(element);
                 lookupWindow.Show();
             }


### PR DESCRIPTION
### Purpose
Add feature  #10 
Support snoop continue element if it is element id can get, it will be use for some case common:
- [x] Need Snoop ElementType of Element
- [x] Need Snoop continue ElementId
- [x] If element id is null (value -1) will be return elementId

### Description
Ex1 : Use to snoop all object return ElementId , in case this, we need continue snoop sheet from get sheetid
![Revit_7yuAskuQV7](https://user-images.githubusercontent.com/31106432/154728183-7c02d935-4f1b-4971-8af6-a96d7b5837c0.png)
Ex2 : GetTypeId
![image](https://user-images.githubusercontent.com/31106432/154729717-2ba2c968-c947-45b2-b3f9-93d4d3cf895b.png)
Ex3 : When ElementId is null or -1 , will be show origin value or user.
![image](https://user-images.githubusercontent.com/31106432/154730044-b04dcb8f-d674-45f7-a2aa-16646c796705.png)
Ex3 : Snoop Continue ICollectionId or ListId ,...
![ShareX_rRiDlw4etp](https://user-images.githubusercontent.com/31106432/154731943-c5d204bc-ae81-463d-a7df-95bd89b68177.png)

### Declarations

Check these if you believe they are true

- [ ] This PR fix bug
- [x] This PR for new feature
- [x] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@weianweigan 

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
