### PR TITLE
Feature extend option pick face,edge

### DIFF
--- a/RevitLookup/Commands/SnoopEdgesCommand.cs
+++ b/RevitLookup/Commands/SnoopEdgesCommand.cs
@@ -28,11 +28,10 @@ namespace RevitLookupWpf.Commands
             var lookupWindow = new LookupWindow(commandData);
             List<GeometryObject> geos = new List<GeometryObject>();
             TaskDialogResult result = MessageUtils.QuestionMsg("Selection Mode:","Single","Normal","Order","Cancel");
-            Document doc = uidoc.Document;
             switch (result)
             {
                 case TaskDialogResult.CommandLink1:
-                    geos = PickSigle(uidoc);
+                    geos = PickSingle(uidoc);
                     break;
                 case TaskDialogResult.CommandLink2:
                     geos = PickNormal(commandData);
@@ -43,10 +42,6 @@ namespace RevitLookupWpf.Commands
                 case TaskDialogResult.CommandLink4:
                     return Result.Succeeded;
             }
-            if (result>=0)
-            {
-                
-            }
             if (geos.Count == 0) return Result.Cancelled;
             if(geos.Count==1) lookupWindow.SetRvtInstance(geos.FirstOrDefault());
             else lookupWindow.SetRvtInstance(geos);
@@ -55,7 +50,7 @@ namespace RevitLookupWpf.Commands
             return Result.Succeeded;
         }
 
-        List<GeometryObject> PickSigle(UIDocument uidoc)
+        List<GeometryObject> PickSingle(UIDocument uidoc)
         {
             List<GeometryObject> geos = new List<GeometryObject>();
             Reference r = uidoc.Selection.PickObject(ObjectType.Edge);

--- a/RevitLookup/Commands/SnoopEdgesCommand.cs
+++ b/RevitLookup/Commands/SnoopEdgesCommand.cs
@@ -19,48 +19,33 @@ namespace RevitLookupWpf.Commands
     {
         public override Result SnoopClick(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            if (commandData.Application.ActiveUIDocument == null)
+            UIDocument uidoc = commandData.Application.ActiveUIDocument;
+            if (uidoc == null)
             {
                 message = Resource.NoActiveDocument;
                 return Result.Cancelled;
             }
             var lookupWindow = new LookupWindow(commandData);
             List<GeometryObject> geos = new List<GeometryObject>();
-            bool isNormal = MessageUtils.QuestionMsg("Selection Mode:","Normal","Order");
-            if (isNormal)
+            TaskDialogResult result = MessageUtils.QuestionMsg("Selection Mode:","Single","Normal","Order","Cancel");
+            Document doc = uidoc.Document;
+            switch (result)
             {
-                try
-                {
-                    var refElem = commandData.Application.ActiveUIDocument.Selection.PickObjects(ObjectType.Edge);
-                    foreach (Reference r in refElem)
-                    {
-                        var geometryObject = commandData.Application.ActiveUIDocument.Document.GetElement(r).GetGeometryObjectFromReference(r);
-                        geos.Add(geometryObject);
-                    }
-                }
-                catch(OperationCanceledException){}
-                catch (Exception e)
-                {
-                    throw new ArgumentException(e.ToString());
-                }
+                case TaskDialogResult.CommandLink1:
+                    geos = PickSigle(uidoc);
+                    break;
+                case TaskDialogResult.CommandLink2:
+                    geos = PickNormal(commandData);
+                    break;
+                case TaskDialogResult.CommandLink3:
+                    geos = PickOrder(commandData);
+                    break;
+                case TaskDialogResult.CommandLink4:
+                    return Result.Succeeded;
             }
-            else
+            if (result>=0)
             {
-                TaskDialog.Show(Resource.AppName, "Select Ordered Edges,Press Esc To Finish", TaskDialogCommonButtons.Ok);
-                while (true)
-                {
-                    try
-                    {
-                        var refElem = commandData.Application.ActiveUIDocument.Selection.PickObject(ObjectType.Edge);
-                        var geometryObject = commandData.Application.ActiveUIDocument.Document.GetElement(refElem).GetGeometryObjectFromReference(refElem);
-                        geos.Add(geometryObject);
-                    }
-                    catch (Exception)
-                    {
-                        //user press esc
-                        break;
-                    }
-                }
+                
             }
             if (geos.Count == 0) return Result.Cancelled;
             if(geos.Count==1) lookupWindow.SetRvtInstance(geos.FirstOrDefault());
@@ -68,6 +53,56 @@ namespace RevitLookupWpf.Commands
             lookupWindow.Show();
 
             return Result.Succeeded;
+        }
+
+        List<GeometryObject> PickSigle(UIDocument uidoc)
+        {
+            List<GeometryObject> geos = new List<GeometryObject>();
+            Reference r = uidoc.Selection.PickObject(ObjectType.Edge);
+            var geometryObject = uidoc.Document.GetElement(r).GetGeometryObjectFromReference(r);
+            geos.Add(geometryObject);
+            return geos;
+        }
+        List<GeometryObject> PickNormal(ExternalCommandData data)
+        {
+            List<GeometryObject> geos = new List<GeometryObject>();
+            try
+            {
+                var refElem = data.Application.ActiveUIDocument.Selection.PickObjects(ObjectType.Edge);
+                foreach (Reference r in refElem)
+                {
+                    var geometryObject = data.Application.ActiveUIDocument.Document.GetElement(r).GetGeometryObjectFromReference(r);
+                    geos.Add(geometryObject);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                throw new ArgumentException(e.ToString());
+            }
+
+            return geos;
+        }
+        List<GeometryObject> PickOrder(ExternalCommandData data)
+        {
+            List<GeometryObject> geos = new List<GeometryObject>();
+            TaskDialog.Show(Resource.AppName, "Select Ordered Edges,Press Esc To Finish", TaskDialogCommonButtons.Ok);
+            while (true)
+            {
+                try
+                {
+                    var refElem = data.Application.ActiveUIDocument.Selection.PickObject(ObjectType.Edge);
+                    var geometryObject = data.Application.ActiveUIDocument.Document.GetElement(refElem).GetGeometryObjectFromReference(refElem);
+                    geos.Add(geometryObject);
+                }
+                catch (Exception)
+                {
+                    //user press esc
+                    break;
+                }
+            }
+
+            return geos;
         }
     }
 }

--- a/RevitLookup/Commands/SnoopFacesCommand.cs
+++ b/RevitLookup/Commands/SnoopFacesCommand.cs
@@ -32,7 +32,7 @@ namespace RevitLookupWpf.Commands
             switch (result)
             {
                 case TaskDialogResult.CommandLink1:
-                    geos = PickSigle(uidoc);
+                    geos = PickSingle(uidoc);
                     break;
                 case TaskDialogResult.CommandLink2:
                     geos = PickNormal(commandData);
@@ -43,10 +43,6 @@ namespace RevitLookupWpf.Commands
                 case TaskDialogResult.CommandLink4:
                     return Result.Succeeded;
             }
-            if (result>=0)
-            {
-                
-            }
             if (geos.Count == 0) return Result.Cancelled;
             if(geos.Count==1) lookupWindow.SetRvtInstance(geos.FirstOrDefault());
             else lookupWindow.SetRvtInstance(geos);
@@ -55,7 +51,7 @@ namespace RevitLookupWpf.Commands
             return Result.Succeeded;
         }
 
-        List<GeometryObject> PickSigle(UIDocument uidoc)
+        List<GeometryObject> PickSingle(UIDocument uidoc)
         {
             List<GeometryObject> geos = new List<GeometryObject>();
             Reference r = uidoc.Selection.PickObject(ObjectType.Face);

--- a/RevitLookup/Commands/SnoopFacesCommand.cs
+++ b/RevitLookup/Commands/SnoopFacesCommand.cs
@@ -27,48 +27,82 @@ namespace RevitLookupWpf.Commands
             }
             var lookupWindow = new LookupWindow(commandData);
             List<GeometryObject> geos = new List<GeometryObject>();
-            bool isNormal = MessageUtils.QuestionMsg("Selection Mode:", "Normal", "Order");
-            if (isNormal)
+            TaskDialogResult result = MessageUtils.QuestionMsg("Selection Mode:","Single","Normal","Order","Cancel");
+            Document doc = uidoc.Document;
+            switch (result)
             {
-                try
-                {
-                    var refElem = commandData.Application.ActiveUIDocument.Selection.PickObjects(ObjectType.Face);
-                    foreach (Reference r in refElem)
-                    {
-                        var geometryObject = commandData.Application.ActiveUIDocument.Document.GetElement(r).GetGeometryObjectFromReference(r);
-                        geos.Add(geometryObject);
-                    }
-                }
-                catch (OperationCanceledException) { }
-                catch (Exception e)
-                {
-                    throw new ArgumentException(e.ToString());
-                }
+                case TaskDialogResult.CommandLink1:
+                    geos = PickSigle(uidoc);
+                    break;
+                case TaskDialogResult.CommandLink2:
+                    geos = PickNormal(commandData);
+                    break;
+                case TaskDialogResult.CommandLink3:
+                    geos = PickOrder(commandData);
+                    break;
+                case TaskDialogResult.CommandLink4:
+                    return Result.Succeeded;
             }
-            else
+            if (result>=0)
             {
-                TaskDialog.Show(Resource.AppName, "Select Ordered Faces,Press Esc To Finish", TaskDialogCommonButtons.Ok);
-                while (true)
-                {
-                    try
-                    {
-                        var refElem = uidoc.Selection.PickObject(ObjectType.Face);
-                        var geometryObject = uidoc.Document.GetElement(refElem).GetGeometryObjectFromReference(refElem);
-                        geos.Add(geometryObject);
-                    }
-                    catch (Exception)
-                    {
-                        //user press esc
-                        break;
-                    }
-                }
+                
             }
             if (geos.Count == 0) return Result.Cancelled;
-            if (geos.Count == 1) lookupWindow.SetRvtInstance(geos.FirstOrDefault());
+            if(geos.Count==1) lookupWindow.SetRvtInstance(geos.FirstOrDefault());
             else lookupWindow.SetRvtInstance(geos);
             lookupWindow.Show();
 
             return Result.Succeeded;
+        }
+
+        List<GeometryObject> PickSigle(UIDocument uidoc)
+        {
+            List<GeometryObject> geos = new List<GeometryObject>();
+            Reference r = uidoc.Selection.PickObject(ObjectType.Face);
+            var geometryObject = uidoc.Document.GetElement(r).GetGeometryObjectFromReference(r);
+            geos.Add(geometryObject);
+            return geos;
+        }
+        List<GeometryObject> PickNormal(ExternalCommandData data)
+        {
+            List<GeometryObject> geos = new List<GeometryObject>();
+            try
+            {
+                var refElem = data.Application.ActiveUIDocument.Selection.PickObjects(ObjectType.Face);
+                foreach (Reference r in refElem)
+                {
+                    var geometryObject = data.Application.ActiveUIDocument.Document.GetElement(r).GetGeometryObjectFromReference(r);
+                    geos.Add(geometryObject);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                throw new ArgumentException(e.ToString());
+            }
+
+            return geos;
+        }
+        List<GeometryObject> PickOrder(ExternalCommandData data)
+        {
+            List<GeometryObject> geos = new List<GeometryObject>();
+            TaskDialog.Show(Resource.AppName, "Select Ordered Edges,Press Esc To Finish", TaskDialogCommonButtons.Ok);
+            while (true)
+            {
+                try
+                {
+                    var refElem = data.Application.ActiveUIDocument.Selection.PickObject(ObjectType.Face);
+                    var geometryObject = data.Application.ActiveUIDocument.Document.GetElement(refElem).GetGeometryObjectFromReference(refElem);
+                    geos.Add(geometryObject);
+                }
+                catch (Exception)
+                {
+                    //user press esc
+                    break;
+                }
+            }
+
+            return geos;
         }
     }
 }

--- a/RevitLookup/Helpers/MessageUtils.cs
+++ b/RevitLookup/Helpers/MessageUtils.cs
@@ -14,7 +14,7 @@ namespace RevitLookupWpf.Helpers
         /// </summary>
         /// <param name="Caption">Title Question</param>
         /// <returns></returns>
-        public static bool QuestionMsg(string Caption, string op1, string op2)
+        public static TaskDialogResult QuestionMsg(string Caption, string op1, string op2,string op3,string op4)
         {
 
             var dialog = new TaskDialog(Caption);
@@ -22,8 +22,9 @@ namespace RevitLookupWpf.Helpers
             dialog.MainInstruction = Caption;
             dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, op1);
             dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, op2);
-
-            return dialog.Show() == TaskDialogResult.CommandLink1;
+            dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink3, op3);
+            dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink4, op4);
+            return dialog.Show();
         }
     }
 }


### PR DESCRIPTION
### Purpose

Extend selection option with face , edge
Single : Only allow user select one object
Normal : Allow user select multiple objects
Order : Select Order Multiple Objects
Cancel : Exit

### Description

Old Option:

![Revit_45bq82kD5p](https://user-images.githubusercontent.com/31106432/154909392-0fc33f03-a7f5-4f36-b11e-a274b75d2ec0.png)

New Option :
![Revit_Y44FRL9PtH](https://user-images.githubusercontent.com/31106432/154909443-1dd00399-156f-45c7-ad79-0558540ae7aa.png)

### Declarations

Check these if you believe they are true

- [ ] This PR fix bug
- [x] This PR for new feature
- [x] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
