### PR TITLE
Improve show detail XYZ,Bodingbox value

### DIFF
--- a/RevitLookup/PropertySys/BaseProperty/MethodType/MethodProperty.cs
+++ b/RevitLookup/PropertySys/BaseProperty/MethodType/MethodProperty.cs
@@ -175,6 +175,7 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.MethodType
                     else
                     {
                         if (tempValue is ElementId id) solvedValue = ResolveElementId(id);
+                        if (tempValue is XYZ xyz) solvedValue = ResolveXYZValue(xyz);
                         else MethodValue = ToolTip;
                     }
                 }
@@ -280,6 +281,12 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.MethodType
             }
             MethodValue = element;
             return false;
+        }
+
+        bool ResolveXYZValue(XYZ xyz)
+        {
+            MethodValue = xyz.ToString();
+            return true;
         }
 
         private void VisitResult(object result)

--- a/RevitLookup/PropertySys/BaseProperty/MethodType/MethodProperty.cs
+++ b/RevitLookup/PropertySys/BaseProperty/MethodType/MethodProperty.cs
@@ -175,7 +175,9 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.MethodType
                     else
                     {
                         if (tempValue is ElementId id) solvedValue = ResolveElementId(id);
-                        if (tempValue is XYZ xyz) solvedValue = ResolveXYZValue(xyz);
+                        else if (tempValue is XYZ xyz) solvedValue = ResolveXYZValue(xyz);
+                        else if (tempValue is BoundingBoxXYZ bbxyz) solvedValue = ResolvebbXYZValue(bbxyz);
+                        else if (tempValue is BoundingBoxUV bbuv) solvedValue = ResolvebbUVValue(bbuv);
                         else MethodValue = ToolTip;
                     }
                 }
@@ -286,7 +288,24 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.MethodType
         bool ResolveXYZValue(XYZ xyz)
         {
             MethodValue = xyz.ToString();
-            return true;
+            return false;
+        }
+
+        bool ResolvebbXYZValue(BoundingBoxXYZ bbXyz)
+        {
+            XYZ minPoint = bbXyz.Min;
+            XYZ maxPoint = bbXyz.Max;
+            XYZ centerPoint = (minPoint + maxPoint) * 0.5;
+            MethodValue = $"Min:{minPoint}\nMax:{maxPoint}\nCenter:{centerPoint}";
+            return false;
+        }
+        bool ResolvebbUVValue(BoundingBoxUV bbuv)
+        {
+            UV minPoint = bbuv.Min;
+            UV maxPoint = bbuv.Max;
+            UV centerPoint = (minPoint + maxPoint) * 0.5;
+            MethodValue = $"Min:{minPoint}\nMax:{maxPoint}\nCenter:{centerPoint}";
+            return false;
         }
 
         private void VisitResult(object result)

--- a/RevitLookup/PropertySys/BaseProperty/ReferenceType/DefaultObjectProperty.cs
+++ b/RevitLookup/PropertySys/BaseProperty/ReferenceType/DefaultObjectProperty.cs
@@ -17,6 +17,7 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.ReferenceType
             if (value != null)
             {
                 if (value is ElementId id) ResolveElementId(value, id);
+                else if(value is XYZ xyz) ResolveXYZValue(xyz);
                 else
                 {
                     Value = value;
@@ -64,6 +65,11 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.ReferenceType
                 Value = element;
                 ValueType = $"<{element.GetType().Name} {element.Name} {element.Id.IntegerValue}>";
             }
+        }
+
+        void ResolveXYZValue(XYZ xyz)
+        {
+            ValueType = xyz.ToString();
         }
     }
 }

--- a/RevitLookup/PropertySys/BaseProperty/ReferenceType/DefaultObjectProperty.cs
+++ b/RevitLookup/PropertySys/BaseProperty/ReferenceType/DefaultObjectProperty.cs
@@ -17,7 +17,7 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.ReferenceType
             if (value != null)
             {
                 if (value is ElementId id) ResolveElementId(value, id);
-                else if(value is XYZ xyz) ResolveXYZValue(xyz);
+                else if(value is XYZ xyz) ResolveXYZValue(value,xyz);
                 else
                 {
                     Value = value;
@@ -67,8 +67,9 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.ReferenceType
             }
         }
 
-        void ResolveXYZValue(XYZ xyz)
+        void ResolveXYZValue(object value,XYZ xyz)
         {
+            Value = value;
             ValueType = xyz.ToString();
         }
     }


### PR DESCRIPTION
### Purpose

- Show detail value XYZ with X,Y,Z for user
- Show detail value BodingboxXYZ for user
- Show detail value BoduingboxUV for user

### Description
**XYZ**
![image](https://user-images.githubusercontent.com/31106432/155059624-c60ec7ae-93bc-47e0-889b-4ae511f1a619.png)
**BoundingboxUV**
![image](https://user-images.githubusercontent.com/31106432/155062902-aad69956-b985-4122-ae78-20be7bd1275e.png)
**BoundingboxXYZ**
![image](https://user-images.githubusercontent.com/31106432/155064679-fbe6c5d4-b949-4631-bddb-1c90a5112e2b.png)

### Declarations

Check these if you believe they are true

- [ ] This PR fix bug
- [x] This PR for new feature
- [ ] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@weianweigan 

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
