### PR TITLE
Add index Enumerable tree view

### DIFF
--- a/RevitLookup/InstanceTree/IEnumerableInstanceNode.cs
+++ b/RevitLookup/InstanceTree/IEnumerableInstanceNode.cs
@@ -8,8 +8,8 @@ namespace RevitLookupWpf.InstanceTree
     {
         public IEnumerableInstanceNode(IEnumerable rvtObject) : base(rvtObject)
         {
-            Name = RvtObject?.GetType().Name;
             GetChild();
+            Name = RvtObject?.GetType().Name + $" [{Children.Count}]";
         }
 
         private void GetChild()
@@ -18,12 +18,20 @@ namespace RevitLookupWpf.InstanceTree
             {
                 Children = new ObservableCollection<InstanceNode>();
             }
-            foreach (var item in RvtObject)
+
+            Index = -1;
+            foreach (object item in RvtObject)
             {
                 InstanceNode node = InstanceNode.Create(item);
                 Children.Add(node);
             }
-            if (Children.Any()) Children = Children.OrderBy(x => x.Name).ToObservableCollection();
+
+            if (Children.Any())
+            {
+                Children = Children.OrderBy(x => x.Name).ToObservableCollection();
+                Children.ToList().ForEach(x=>x.Index= Index+=1);
+                Children.ToList().ForEach(x=>x.Name= $"[{x.Index}] {x.Name}");
+            }
         }
 
     }

--- a/RevitLookup/InstanceTree/InstanceNode.cs
+++ b/RevitLookup/InstanceTree/InstanceNode.cs
@@ -120,7 +120,7 @@ namespace RevitLookupWpf.InstanceTree
                         node = new BoundingBoxXYZInstanceNode(boundsXYZ);
                         break;
                     case EdgeArray edgeArray:
-                        node = new IEnumerableInstanceNode(edgeArray);
+                        node = new EdgeArrayInstanceNode(edgeArray);
                         node.IsExpanded = true;
                         break;
                     default:
@@ -136,8 +136,8 @@ namespace RevitLookupWpf.InstanceTree
         #endregion
 
         #region Properties
-        public string Name { get; protected set; }
-
+        public string Name { get; protected internal set; }
+        public int Index { get; set; }
         public bool IsSelected
         {
             get => _isSelected; set


### PR DESCRIPTION
### Purpose

Add index and size to tree view snoop object

![Revit_Em81HjN8hv](https://user-images.githubusercontent.com/31106432/189525751-ebb98cab-ef92-4f94-baea-9bbf09cf9870.png)


### Description

It was useful for user snoop and see history by index, in case we use in Dynamo Revit, some object will be easy to track history by index key. 

![image](https://user-images.githubusercontent.com/31106432/189526157-a9519ef6-97e2-4f6e-958c-2656244337a2.png)

### Declarations

Check these if you believe they are true

- [ ] This PR fix bug
- [x] This PR for new feature
- [x] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@weianweigan 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
