### PR TITLE
Improve way show value type on datagrid property value

### DIFF
--- a/RevitLookup/PropertySys/BaseProperty/ReferenceType/DefaultObjectProperty.cs
+++ b/RevitLookup/PropertySys/BaseProperty/ReferenceType/DefaultObjectProperty.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows;
-using System.Windows.Input;
-using Autodesk.Revit.DB;
+﻿using System.Windows.Input;
 using GalaSoft.MvvmLight.Command;
 using RevitLookupWpf.View;
 
@@ -15,10 +13,9 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.ReferenceType
             if (value != null)
             {
                 Value = value;
-                ValueType = value.GetType()?.Name;
+                ValueType = value.GetType()?.FullName;
             }
         }
-
         public string ValueType { get; set; }
 
         public ICommand SelectedCommand => _selectedCommand ??= new RelayCommand(Selected);
@@ -37,5 +34,6 @@ namespace RevitLookupWpf.PropertySys.BaseProperty.ReferenceType
                 NaviRvtObj(Value);
             }
         }
+        
     }
 }

--- a/RevitLookup/Themes/PropertyDataGrid.xaml
+++ b/RevitLookup/Themes/PropertyDataGrid.xaml
@@ -124,7 +124,7 @@
                 </Grid>
             </DataTemplate>
         </controls:PropertyDataGridValueTemplateSelector.ExceptionDataTemplate>
-        <!--  DeafultObject  -->
+        <!--  Default Object  -->
         <controls:PropertyDataGridValueTemplateSelector.DefaultObjectDataTemplate>
             <DataTemplate DataType="{x:Type referenceType:DefaultObjectProperty}">
                 <TextBlock FontWeight="Black" Text="{Binding ValueType}">


### PR DESCRIPTION
### Purpose

It Useful for some user not use Intellisense or use Python code or user use snoop both type DynamoAPI object and RevitAPI Object
Example Element : 
- Revit.Elements.Element (Dynamo Revit Node Library) instead of **Element**
- Autodesk.Revit.DB.Element (Revit API) instead of **Element**

### Description
![Revit_cfj9kNAdLW](https://user-images.githubusercontent.com/31106432/189528629-0c8ac53f-c869-4d0f-999d-5088b448be40.png)

### Declarations

Check these if you believe they are true

- [ ] This PR fix bug
- [ ] This PR for new feature
- [x] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@weianweigan 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
